### PR TITLE
Enable direct URL sharing for map POCs

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/app-gisat-deckglSandbox/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox deck.gl</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/app-gisat-deckglSandbox/src/main.jsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Add 404.html for GitHub Pages SPA routing

This enables direct URL access to map POCs on GitHub Pages.

Previously, direct links like /cog-kernel would return 404 errors because GitHub Pages tried to find a file at that path. Now users can share direct links and they will work correctly.

The 404.html file is served by GitHub Pages for non-existent routes, allowing React Router to handle client-side routing.

Example: https://gisat.github.io/app-gisat-deckglSandbox/cog-kernel