### PR TITLE
style: unify UI fonts and sizes across 3DFLUS CCN maps

### DIFF
--- a/src/components/PlaybackControls.jsx
+++ b/src/components/PlaybackControls.jsx
@@ -13,7 +13,7 @@ export const PlaybackControls = ({
 }) => {
     return (
         <div style={{
-            position: 'absolute', bottom: 30, left: 'calc(50% - 400px)', transform: 'translateX(0)',
+            position: 'absolute', bottom: 10, left: 'calc(50% - 400px)', transform: 'translateX(0)',
             width: '60%', maxWidth: '400px', background: 'rgba(255, 255, 255, 0.95)', padding: '11px',
             borderRadius: '8px', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)', fontFamily: 'system-ui, sans-serif', fontSize: '13px', color: '#333', zIndex: 1000
         }}>

--- a/src/components/PlaybackControls.jsx
+++ b/src/components/PlaybackControls.jsx
@@ -13,7 +13,7 @@ export const PlaybackControls = ({
 }) => {
     return (
         <div style={{
-            position: 'absolute', bottom: 10, left: 'calc(50% - 400px)', transform: 'translateX(0)',
+            position: 'absolute', bottom: 10, left: 'max(10px, calc(50% - 400px))', transform: 'translateX(0)',
             width: '60%', maxWidth: '400px', background: 'rgba(255, 255, 255, 0.95)', padding: '11px',
             borderRadius: '8px', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)', fontFamily: 'system-ui, sans-serif', fontSize: '13px', color: '#333', zIndex: 1000
         }}>

--- a/src/components/PlaybackControls.jsx
+++ b/src/components/PlaybackControls.jsx
@@ -13,9 +13,9 @@ export const PlaybackControls = ({
 }) => {
     return (
         <div style={{
-            position: 'absolute', bottom: 30, left: '50%', transform: 'translateX(-50%)',
-            width: '80%', maxWidth: '600px', backgroundColor: 'white', padding: '15px',
-            borderRadius: '8px', boxShadow: '0 4px 12px rgba(0,0,0,0.2)', fontFamily: 'sans-serif', zIndex: 10
+            position: 'absolute', bottom: 30, left: 'calc(50% - 400px)', transform: 'translateX(0)',
+            width: '60%', maxWidth: '400px', background: 'rgba(255, 255, 255, 0.95)', padding: '11px',
+            borderRadius: '8px', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)', fontFamily: 'system-ui, sans-serif', fontSize: '13px', color: '#333', zIndex: 1000
         }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
                 <div style={{ fontWeight: 'bold' }}>

--- a/src/components/PointSelection/SelectionControls.jsx
+++ b/src/components/PointSelection/SelectionControls.jsx
@@ -13,6 +13,8 @@
  * @param {boolean} props.isLoadingBackend - Whether backend query is in progress
  * @param {number} props.bufferDistance - Current buffer distance (for line mode)
  * @param {Function} props.onBufferChange - Called with new buffer distance
+ * @param {string} props.top - Top position (default: '130px')
+ * @param {string} props.left - Left position (default: '10px')
  */
 export function SelectionControls({
     selectionMode,
@@ -22,7 +24,9 @@ export function SelectionControls({
     backendFeatureCount = 0,
     isLoadingBackend = false,
     bufferDistance = 100,
-    onBufferChange
+    onBufferChange,
+    top = '130px',
+    left = '10px'
 }) {
     const modes = ['polygon', 'circle', 'line'];
 
@@ -30,8 +34,8 @@ export function SelectionControls({
         <div
             style={{
                 position: 'absolute',
-                top: '130px',
-                left: '10px',
+                top,
+                left,
                 background: 'rgba(255, 255, 255, 0.95)',
                 borderRadius: '8px',
                 padding: '12px',

--- a/src/components/PointSelection/SelectionControls.jsx
+++ b/src/components/PointSelection/SelectionControls.jsx
@@ -38,13 +38,13 @@ export function SelectionControls({
                 boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
                 zIndex: 1000,
                 fontFamily: 'system-ui, sans-serif',
-                fontSize: '12px',
+                fontSize: '13px',
                 minWidth: '220px'
             }}
         >
             {/* Mode Selector */}
             <div style={{ marginBottom: '12px' }}>
-                <label style={{ display: 'block', marginBottom: '8px', fontSize: '12px', fontWeight: 'bold' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontSize: '13px', fontWeight: 'bold' }}>
                     Point Selection - Drawing Mode:
                 </label>
                 <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
@@ -73,7 +73,7 @@ export function SelectionControls({
             {/* Line Buffer Distance (only for line mode) */}
             {selectionMode === 'line' && (
                 <div style={{ marginBottom: '12px' }}>
-                    <label style={{ display: 'block', marginBottom: '6px', fontSize: '12px', fontWeight: '500' }}>
+                    <label style={{ display: 'block', marginBottom: '6px', fontSize: '11px', fontWeight: '500' }}>
                         Buffer Distance: {bufferDistance}m
                     </label>
                     <input
@@ -83,7 +83,7 @@ export function SelectionControls({
                         step="10"
                         value={bufferDistance}
                         onChange={e => onBufferChange(Number(e.target.value))}
-                        style={{ width: '100%', fontSize: '12px' }}
+                        style={{ width: '100%', fontSize: '11px' }}
                     />
                 </div>
             )}
@@ -117,7 +117,7 @@ export function SelectionControls({
                             border: '1px solid #ddd',
                             borderRadius: '3px',
                             cursor: 'pointer',
-                            fontSize: '10px',
+                            fontSize: '11px',
                             fontWeight: '600',
                             whiteSpace: 'nowrap',
                             marginLeft: '8px'

--- a/src/components/PointSelection/TimeSeriesChart.css
+++ b/src/components/PointSelection/TimeSeriesChart.css
@@ -1,10 +1,13 @@
 .DSI-TimeSeriesChart {
     position: relative;
-    margin: 12px 0;
+    margin: 0px 0;
     background: rgba(255, 255, 255, 0.95);
     border-radius: 8px;
     padding: 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    font-family: system-ui, sans-serif;
+    font-size: 11px;
+    color: #333;
 }
 
 .DSI-TimeSeriesChart-overlay {
@@ -34,16 +37,16 @@
 }
 
 .DSI-TimeSeriesChart-chart {
-    height: 320px;
+    height: 260px;
 }
 
 .DSI-TimeSeriesChart-empty {
-    height: 320px;
+    height: 260px;
     display: flex;
     align-items: center;
     justify-content: center;
     color: #999;
-    font-size: 14px;
+    font-size: 11px;
 }
 
 .DSI-TimeSeriesChart-tooltip {
@@ -51,7 +54,8 @@
     border: 1px solid var(--mantine-color-gray-3, #dee2e6);
     border-radius: 4px;
     padding: 8px 12px;
-    font-size: 12px;
+    font-size: 11px;
     line-height: 1.6;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    font-family: system-ui, sans-serif;
 }

--- a/src/maps/ArrowLODStream_2D/Map2D.jsx
+++ b/src/maps/ArrowLODStream_2D/Map2D.jsx
@@ -349,7 +349,8 @@ function ArrowLODStream2D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: 'calc(50% + 420px)',
+                    width: 'calc(50% - 430px)',
+                    minWidth: '300px',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/ArrowLODStream_2D/Map2D.jsx
+++ b/src/maps/ArrowLODStream_2D/Map2D.jsx
@@ -349,8 +349,7 @@ function ArrowLODStream2D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: '10px',
-                    maxWidth: '600px',
+                    right: 'calc(50% + 420px)',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/ArrowLODStream_3D/Map3D.jsx
+++ b/src/maps/ArrowLODStream_3D/Map3D.jsx
@@ -492,8 +492,7 @@ function ArrowLODStream3D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: '10px',
-                    maxWidth: '600px',
+                    right: 'calc(50% + 420px)',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/ArrowLODStream_3D/Map3D.jsx
+++ b/src/maps/ArrowLODStream_3D/Map3D.jsx
@@ -492,7 +492,8 @@ function ArrowLODStream3D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: 'calc(50% + 420px)',
+                    width: 'calc(50% - 430px)',
+                    minWidth: '300px',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/GeoParquetDuckDB_2D/Map2D.jsx
+++ b/src/maps/GeoParquetDuckDB_2D/Map2D.jsx
@@ -349,7 +349,8 @@ function Map2D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: 'calc(50% + 420px)',
+                    width: 'calc(50% - 430px)',
+                    minWidth: '300px',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/GeoParquetDuckDB_2D/Map2D.jsx
+++ b/src/maps/GeoParquetDuckDB_2D/Map2D.jsx
@@ -349,8 +349,7 @@ function Map2D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: '10px',
-                    maxWidth: '600px',
+                    right: 'calc(50% + 420px)',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/GeoParquetDuckDB_3D/Map3D.jsx
+++ b/src/maps/GeoParquetDuckDB_3D/Map3D.jsx
@@ -489,8 +489,7 @@ function Map3D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: '10px',
-                    maxWidth: '600px',
+                    right: 'calc(50% + 420px)',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/GeoParquetDuckDB_3D/Map3D.jsx
+++ b/src/maps/GeoParquetDuckDB_3D/Map3D.jsx
@@ -489,7 +489,8 @@ function Map3D() {
                     position: 'absolute',
                     bottom: '10px',
                     left: '10px',
-                    right: 'calc(50% + 420px)',
+                    width: 'calc(50% - 430px)',
+                    minWidth: '300px',
                     zIndex: 999,
                 }}>
                     <TimeSeriesChart 

--- a/src/maps/GisatDataService/index.jsx
+++ b/src/maps/GisatDataService/index.jsx
@@ -303,9 +303,9 @@ export default function GisatDataService() {
 
   return (
     <>
-      <div style={{ position: 'absolute', top: '10px', left: '10px', zIndex: 10, backgroundColor: '#f0f0f0', padding: '10px', borderRadius: '4px', boxShadow: '0 0 0 2px rgba(0,0,0,0.1)' }}>
+      <div style={{ position: 'absolute', top: '10px', left: '10px', zIndex: 10, background: 'rgba(255, 255, 255, 0.95)', padding: '11px', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)', fontFamily: 'system-ui, sans-serif', fontSize: '13px', color: '#333', width: '260px' }}>
         {LAYER_CONFIGS.map((config) => (
-          <label key={config.id} style={{ display: 'flex', alignItems: 'center', gap: '8px', margin: config === LAYER_CONFIGS[0] ? '0 0 8px 0' : '8px 0 0 0', fontSize: '14px' }}>
+          <label key={config.id} style={{ display: 'flex', alignItems: 'center', gap: '8px', margin: config === LAYER_CONFIGS[0] ? '0 0 8px 0' : '8px 0 0 0', fontSize: '13px' }}>
             <input
               type="checkbox"
               checked={layerVisibility[config.id]}

--- a/src/maps/Misicuni_dam/index.jsx
+++ b/src/maps/Misicuni_dam/index.jsx
@@ -374,8 +374,8 @@ function MisicuniDam() {
       <div
         style={{
           position: 'absolute',
-          bottom: 20,
-          left: 20,
+          top: 10,
+          left: 10,
           background: 'rgba(255, 255, 255, 0.95)',
           padding: '11px',
           borderRadius: '8px',
@@ -383,7 +383,7 @@ function MisicuniDam() {
           fontFamily: 'system-ui, sans-serif',
           fontSize: '13px',
           color: '#333',
-          width: '220px',
+          width: '240px',
           zIndex: 1000,
         }}
       >
@@ -398,7 +398,7 @@ function MisicuniDam() {
                 onChange={(e) => setLayerVisibility(prev => ({ ...prev, [layer.id]: e.target.checked }))}
                 style={{ cursor: 'pointer', width: '16px', height: '16px' }}
               />
-              <label htmlFor={layer.id} style={{ cursor: 'pointer', fontSize: '11px', flex: 1, userSelect: 'none' }}>
+              <label htmlFor={layer.id} style={{ cursor: 'pointer', fontSize: '13px', flex: 1, userSelect: 'none' }}>
                 {layer.name}
               </label>
             </div>
@@ -422,7 +422,7 @@ function MisicuniDam() {
                 border: 'none',
                 borderRadius: '3px',
                 fontWeight: 'normal',
-                fontSize: '11px',
+                fontSize: '13px',
               }}
             >
               {isFetched ? '✅ Ready' : '⬇️ Load data'}

--- a/src/maps/Misicuni_dam/index.jsx
+++ b/src/maps/Misicuni_dam/index.jsx
@@ -377,18 +377,18 @@ function MisicuniDam() {
           bottom: 20,
           left: 20,
           background: 'rgba(255, 255, 255, 0.95)',
-          padding: '12px',
+          padding: '11px',
           borderRadius: '8px',
           boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
           fontFamily: 'system-ui, sans-serif',
-          fontSize: '14px',
+          fontSize: '13px',
           color: '#333',
           width: '220px',
           zIndex: 1000,
         }}
       >
         {/* Layer Visibility - Checkboxes FIRST */}
-        <div style={{ marginBottom: '16px', paddingBottom: '12px', borderBottom: '1px solid #ddd' }}>
+        <div style={{ marginBottom: '16px', paddingBottom: '11px', borderBottom: '1px solid #ddd' }}>
           {VECTOR_POINT_DATA.map((layer) => (
             <div key={layer.id} style={{ marginBottom: '6px', display: 'flex', alignItems: 'center', gap: '8px' }}>
               <input
@@ -398,7 +398,7 @@ function MisicuniDam() {
                 onChange={(e) => setLayerVisibility(prev => ({ ...prev, [layer.id]: e.target.checked }))}
                 style={{ cursor: 'pointer', width: '16px', height: '16px' }}
               />
-              <label htmlFor={layer.id} style={{ cursor: 'pointer', fontSize: '12px', flex: 1, userSelect: 'none' }}>
+              <label htmlFor={layer.id} style={{ cursor: 'pointer', fontSize: '11px', flex: 1, userSelect: 'none' }}>
                 {layer.name}
               </label>
             </div>
@@ -422,14 +422,14 @@ function MisicuniDam() {
                 border: 'none',
                 borderRadius: '3px',
                 fontWeight: 'normal',
-                fontSize: '10px',
+                fontSize: '11px',
               }}
             >
               {isFetched ? '✅ Ready' : '⬇️ Load data'}
             </button>
           </div>
           {currentDescription && (
-            <div style={{ marginBottom: '8px', fontSize: '13px', fontWeight: '500', color: '#555' }}>
+            <div style={{ marginBottom: '8px', fontSize: '11px', fontWeight: '500', color: '#555' }}>
               Date: {currentDescription} ({currentBandIndex + 1}/{totalBands})
             </div>
           )}
@@ -469,7 +469,7 @@ function MisicuniDam() {
           {showLegend && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginTop: '2px' }}>
               {VELOCITY_COLOR_SCALE.map((entry, idx) => (
-                <div key={idx} style={{ display: 'flex', alignItems: 'center', gap: '3px', fontSize: '9px' }}>
+                <div key={idx} style={{ display: 'flex', alignItems: 'center', gap: '3px', fontSize: '11px' }}>
                   <span 
                     style={{ 
                       display: 'inline-block', 
@@ -511,7 +511,7 @@ function MisicuniDam() {
           {showLegend2 && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginTop: '2px' }}>
               {VEL_RE_EW_COLOR_SCALE.map((entry, idx) => (
-                <div key={idx} style={{ display: 'flex', alignItems: 'center', gap: '3px', fontSize: '9px' }}>
+                <div key={idx} style={{ display: 'flex', alignItems: 'center', gap: '3px', fontSize: '11px' }}>
                   <span 
                     style={{ 
                       display: 'inline-block', 

--- a/src/maps/SelectionDrawing3D/index.jsx
+++ b/src/maps/SelectionDrawing3D/index.jsx
@@ -319,8 +319,8 @@ export default function SelectionDrawing3D() {
           position: 'absolute',
           bottom: '10px',
           left: '10px',
-          right: '10px',
-          maxWidth: '600px',
+          width: 'calc(50% - 430px)',
+          minWidth: '300px',
           zIndex: 999,
         }}>
           <TimeSeriesChart

--- a/src/maps/SelectionDrawing3D/index.jsx
+++ b/src/maps/SelectionDrawing3D/index.jsx
@@ -301,6 +301,8 @@ export default function SelectionDrawing3D() {
           // keep drawing active if selection mode is still selected
           setIsDrawing(selectionMode ? true : false);
         }}
+        top="10px"
+        left="10px"
       />
 
       <DrawingOverlay


### PR DESCRIPTION
Standardize typography and component positioning across map applications.

## Changes
- Unified font family to system-ui, sans-serif across all UI components
- Standardized font sizes: 13px (primary), 11px (secondary)
- Updated components:
  - Misicuni_dam: control panel styling
  - GisatDataService: font and size standardization
  - ArrowLODStream_2D: HUD, PlaybackControls, SelectionControls, TimeSeriesChart
  - GeoParquetDuckDB_2D/3D: TimeSeriesChart width standardization
  - ArrowLODStream_3D: TimeSeriesChart width standardization
  - SelectionDrawing3D: SelectionControls positioning
- Made SelectionControls positioning customizable via props
- Standardized TimeSeriesChart width: right: calc(50% + 420px)