### PR TITLE
feat: Update @gisatcz/deckgl-geolib package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@developmentseed/deck.gl-geotiff": "^0.1.0",
         "@duckdb/duckdb-wasm": "^1.29.0",
         "@geoarrow/deck.gl-layers": "^0.3.1",
-        "@gisatcz/deckgl-geolib": "2.6.0-dev.4",
+        "@gisatcz/deckgl-geolib": "2.6.0-dev.6",
         "@loaders.gl/3d-tiles": "^4.4.1",
         "@loaders.gl/arrow": "^4.4.1",
         "@loaders.gl/core": "^4.4.1",
@@ -1536,9 +1536,9 @@
       }
     },
     "node_modules/@gisatcz/deckgl-geolib": {
-      "version": "2.6.0-dev.4",
-      "resolved": "https://registry.npmjs.org/@gisatcz/deckgl-geolib/-/deckgl-geolib-2.6.0-dev.4.tgz",
-      "integrity": "sha512-svgeR/M64NhzEu6OXz1/BuIzODYmYmxFUmJHfD9ZydFKtw1KLdMr4ZpH8ngtHcrWbAjDsVYHbS5+NDU8+ey7hw==",
+      "version": "2.6.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@gisatcz/deckgl-geolib/-/deckgl-geolib-2.6.0-dev.6.tgz",
+      "integrity": "sha512-0WS4z6NDIFvcHhIpVNBEv3/gw4fKA96bBe3VSa6BOUgANt6HnypKjI2UIKDOkB0ajspNKukLPu4FNM+SU5bntw==",
       "license": "MIT",
       "dependencies": {
         "@mapbox/martini": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@developmentseed/deck.gl-geotiff": "^0.1.0",
     "@duckdb/duckdb-wasm": "^1.29.0",
     "@geoarrow/deck.gl-layers": "^0.3.1",
-    "@gisatcz/deckgl-geolib": "2.6.0-dev.4",
+    "@gisatcz/deckgl-geolib": "2.6.0-dev.6",
     "@loaders.gl/3d-tiles": "^4.4.1",
     "@loaders.gl/arrow": "^4.4.1",
     "@loaders.gl/core": "^4.4.1",


### PR DESCRIPTION
Bumps @gisatcz/deckgl-geolib dependency from 2.6.0-dev.4 to 2.6.0-dev.6.