### PR TITLE
fix(ui): Enforce light theme on UI components

### DIFF
--- a/src/components/HUD.jsx
+++ b/src/components/HUD.jsx
@@ -5,6 +5,7 @@ export const HUD = ({ viewState, currentTierDisplay, totalPoints, fetchStatus, i
             backgroundColor: 'rgba(255, 255, 255, 0.9)', padding: '10px 15px',
             borderRadius: '8px', boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
             fontFamily: 'monospace', fontSize: '12px', zIndex: 10,
+            color: '#333',
             pointerEvents: 'none' // Click through
         }}>
             <div><b>Zoom:</b> {viewState.zoom?.toFixed(2)}</div>

--- a/src/components/PointSelection/SelectionControls.jsx
+++ b/src/components/PointSelection/SelectionControls.jsx
@@ -47,6 +47,7 @@ export function SelectionControls({
                 zIndex: 1000,
                 fontFamily: 'system-ui, sans-serif',
                 fontSize: '13px',
+                color: '#333',
                 minWidth: '220px'
             }}
         >
@@ -65,6 +66,7 @@ export function SelectionControls({
                                 border: selectionMode === mode ? '2px solid #0066cc' : '1px solid #ccc',
                                 borderRadius: '4px',
                                 background: selectionMode === mode ? '#e6f0ff' : '#fff',
+                                color: '#333',
                                 cursor: 'pointer',
                                 fontSize: '11px',
                                 fontWeight: selectionMode === mode ? '600' : '400',


### PR DESCRIPTION
This PR applies a quick fix to several UI components to ensure they render correctly when a browser's "force dark mode" feature is active.

By adding an explicit `color: '#333'` to their styles, the following components now consistently display with a light theme, preventing unreadable text:

- `HUD.jsx`
- `SelectionControls.jsx`